### PR TITLE
fix: Load abst failed json: cannot unmarshal number 100000 into Go st…

### DIFF
--- a/v3/types/types.go
+++ b/v3/types/types.go
@@ -24,7 +24,7 @@ type CoinsMarket []CoinsMarketItem
 // CoinsID https://api.coingecko.com/api/v3/coins/bitcoin
 type CoinsID struct {
 	coinBaseStruct
-	BlockTimeInMin      int16               `json:"block_time_in_minutes"`
+	BlockTimeInMin      int32               `json:"block_time_in_minutes"`
 	Categories          []string            `json:"categories"`
 	Localization        LocalizationItem    `json:"localization"`
 	Description         DescriptionItem     `json:"description"`


### PR DESCRIPTION
…ruct field CoinsID.block_time_in_minutes of type int16