### PR TITLE
change float32 to float64

### DIFF
--- a/v3/types/model.go
+++ b/v3/types/model.go
@@ -69,7 +69,7 @@ type DescriptionItem map[string]string
 type LinksItem map[string]interface{}
 
 // ChartItem
-type ChartItem [2]float32
+type ChartItem [2]float64
 
 // MarketDataItem map all market data item
 type MarketDataItem struct {


### PR DESCRIPTION
@superoo7 Time is gained or lost due to the use of float32 for the type ChartItem.

Currently the following data is produced but it is incorrect 
2021-03-07T00:00:13Z  49019.3672  Epoch:1615075213312.000000
2021-03-07T23:59:49Z  51313.0938  Epoch:1615161589760.000000
The correct data should be
2021-03-07T00:00:00Z  49019.3686  Epoch:16150752**00000**.000000
2021-03-0**8**T00:00:00Z  51313.0926  Epoch:1615161**600000**.000000

Code attached to reproduce the issue
[issue.txt](https://github.com/superoo7/go-gecko/files/6114517/issue.txt)

